### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
     :target: https://readthedocs.org/projects/mvp/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://pypip.in/version/mvp/badge.svg
+.. image:: https://img.shields.io/pypi/v/mvp.svg
     :target: https://testpypi.python.org/pypi/mvp/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mvp))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mvp`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.